### PR TITLE
Dinamic queues

### DIFF
--- a/src/clases/cola.py
+++ b/src/clases/cola.py
@@ -135,7 +135,10 @@ class Cola:
         await self.actualizarMensajeExistente()
 
     # Enviar un mensaje nuevo sobre la cola
-    async def enviarMensajeNuevo(self):
+    async def enviarMensajeNuevo(self, channel):
+        # Fijo el canal del mensaje al que me enviaron
+        self.canalMensaje = channel
+
         # Genero embed a enviar
         embedCompleto = self.generarMensajeEmbed()
 

--- a/src/clases/colas.py
+++ b/src/clases/colas.py
@@ -30,8 +30,8 @@ class Colas:
 
     # Agregar una nueva cola
     @classmethod
-    def agregarCola(cls, nombreCola):
-        cls.colasActuales.append(Cola(nombreCola))
+    def agregarCola(cls, nombreCola, canalEnviado):
+        cls.colasActuales.append(Cola(nombreCola, canalEnviado))
 
     # Quitar una cola existente
     @classmethod
@@ -106,6 +106,5 @@ class Colas:
         await cls.getColaPorNombre(nombreCola).eliminarMensaje()
 
     @classmethod
-    async def enviarMensajeNextEnCola(cls, nombreCola, canalOutputBot):
-        await cls.getColaPorNombre(nombreCola).enviarMensajeNext(
-            canalOutputBot)
+    async def enviarMensajeNextEnCola(cls, nombreCola):
+        await cls.getColaPorNombre(nombreCola).enviarMensajeNext()

--- a/src/clases/colas.py
+++ b/src/clases/colas.py
@@ -94,8 +94,8 @@ class Colas:
     # --- Son awaited porque envian mensajes ---
 
     @classmethod
-    async def enviarMensajeNuevoEnCola(cls, nombreCola):
-        await cls.getColaPorNombre(nombreCola).enviarMensajeNuevo()
+    async def enviarMensajeNuevoEnCola(cls, nombreCola, channel):
+        await cls.getColaPorNombre(nombreCola).enviarMensajeNuevo(channel)
 
     @classmethod
     async def actualizarMensajeExistenteEnCola(cls, nombreCola):

--- a/src/comandos/comandoAdd.py
+++ b/src/comandos/comandoAdd.py
@@ -12,8 +12,8 @@ prefijoBot = Configs.prefijoBot
 
 # Description: Agregar una persona a una cola
 # Access: Everyone
-async def manejarComandoAdd(mensaje, autorMensaje, tagAlAutor, voiceState):
-    canalSpamComandos = GlobalVariables.canalSpamComandos
+async def manejarComandoAdd(mensaje, autorMensaje, tagAlAutor, voiceState, channel):
+    canalSpamComandos = GlobalVariables.canalOutputComandos
 
     parametrosMensaje = mensaje.split(" ", 5)
 
@@ -24,14 +24,14 @@ async def manejarComandoAdd(mensaje, autorMensaje, tagAlAutor, voiceState):
     if cantidadDeParametrosEs(4, parametrosMensaje):
         # Debo checkear que sea mod antes de ejecutar este path
         if not esMod(autorMensaje):
-            await printearErrorSinPermisos(autorMensaje, comandoAdd)
+            await printearErrorSinPermisos(autorMensaje, comandoAdd, channel)
             return False
         tieneNombreEscrito = True
         nombreEscrito = parametrosMensaje[3]
 
     # Solo debe haber tres parametros (si no pasa lo anterior)
     elif not cantidadDeParametrosEs(3, parametrosMensaje):
-        await canalSpamComandos.send(
+        await channel.send(
             f"Sintaxis incorrecta, uso: `{prefijoBot} {comandoAdd} nombreCola`."
         )
         return False
@@ -39,29 +39,30 @@ async def manejarComandoAdd(mensaje, autorMensaje, tagAlAutor, voiceState):
     nombreCola = parametrosMensaje[2]
 
     if not Colas.existeCola(nombreCola):
-        await canalSpamComandos.send(f"No existe la cola **{nombreCola}**!")
+        await channel.send(f"No existe la cola **{nombreCola}**!")
         return False
+
+    # Si ya esta en la cola y el nombre no viene escrito
+    if Colas.existeUsuarioEnCola(autorMensaje, nombreCola) and not tieneNombreEscrito:
+        await channel.send(
+            f"{tagAlAutor} ya estas en la cola **{nombreCola}**!")
+        return False
+
+    # No esta en ningun canal de voz y el nombre no viene escrito
+    if voiceState is None and not tieneNombreEscrito:
+        await channel.send(
+            f"{tagAlAutor} para unirte a la cola necesitas estar conectado en algun canal de soporte!")
+        return False
+
+    # El nombre viene dado en el mensaje
+    if tieneNombreEscrito:
+        Colas.agregarUsuarioACola(nombreEscrito, nombreCola, "n/a")
+        await canalSpamComandos.send(
+            f"{nombreEscrito} ha sido agregado a la cola **{nombreCola}**.")
+    # Se agrega a la persona que envio el mensaje
     else:
-        if Colas.existeUsuarioEnCola(autorMensaje, nombreCola) and not tieneNombreEscrito:
-            await canalSpamComandos.send(
-                f"{tagAlAutor} ya estas en la cola **{nombreCola}**!")
-            return False
-        else:
-            # No esta en ningun canal de voz, y el nombre no viene escrito
-            if voiceState is None and not tieneNombreEscrito:
-                await canalSpamComandos.send(f"{tagAlAutor} para unirte a la cola necesitas estar conectado "
-                                             f"en algun canal de soporte!")
-                return False
-            else:
-                # El nombre viene dado en el mensaje
-                if tieneNombreEscrito:
-                    Colas.agregarUsuarioACola(nombreEscrito, nombreCola, "n/a")
-                    await canalSpamComandos.send(
-                        f"{nombreEscrito} ha sido agregado a la cola **{nombreCola}**.")
-                # Se agrega a la persona que envio el mensaje
-                else:
-                    Colas.agregarUsuarioACola(autorMensaje, nombreCola, voiceState.channel)
-                    await canalSpamComandos.send(
-                        f"{tagAlAutor} ha sido agregado a la cola **{nombreCola}**.")
-                await Colas.actualizarMensajeExistenteEnCola(nombreCola)
-                return True
+        Colas.agregarUsuarioACola(autorMensaje, nombreCola, voiceState.channel)
+        await canalSpamComandos.send(
+            f"{tagAlAutor} ha sido agregado a la cola **{nombreCola}**.")
+    await Colas.actualizarMensajeExistenteEnCola(nombreCola)
+    return True

--- a/src/comandos/comandoAll.py
+++ b/src/comandos/comandoAll.py
@@ -12,14 +12,14 @@ imagenThumbnail = Configs.imagenThumbnail
 
 # Description: Mostrar todas las colas existentes
 # Access: Only Mods
-async def manejarComandoAll(autorMensaje):
+async def manejarComandoAll(autorMensaje, channel):
 
     # Verificacion de mod
     if not esMod(autorMensaje):
-        await printearErrorSinPermisos(autorMensaje, comandoAll)
+        await printearErrorSinPermisos(autorMensaje, comandoAll, channel)
         return False
 
-    canalSpamComandos = GlobalVariables.canalSpamComandos
+    canalSpamComandos = GlobalVariables.canalOutputComandos
 
     mensajeEmbed = Colas.generarMensajeListandoColas()
 

--- a/src/comandos/comandoCreate.py
+++ b/src/comandos/comandoCreate.py
@@ -12,19 +12,19 @@ prefijoBot = Configs.prefijoBot
 
 # Description: Crea un nueva cola y la agrega a la lista
 # Access: Only Mods
-async def manejarComandoCreate(mensaje, autorMensaje, tagAlAutor):
+async def manejarComandoCreate(mensaje, autorMensaje, tagAlAutor, channel):
     # Verificacion de mod
     if not esMod(autorMensaje):
-        await printearErrorSinPermisos(autorMensaje, comandoCreate)
+        await printearErrorSinPermisos(autorMensaje, comandoCreate, channel)
         return False
 
-    canalSpamComandos = GlobalVariables.canalSpamComandos
+    canalSpamComandos = GlobalVariables.canalOutputComandos
 
     parametrosMensaje = mensaje.split(" ", 5)
 
     # Solo debe haber tres parametros {!queue}, {create}, {elNombre}
     if not cantidadDeParametrosEs(3, parametrosMensaje):
-        await canalSpamComandos.send(
+        await channel.send(
             f"Sintaxis incorrecta, uso: `{prefijoBot} {comandoCreate} nombreCola`"
         )
         return False
@@ -32,13 +32,13 @@ async def manejarComandoCreate(mensaje, autorMensaje, tagAlAutor):
     nombreCola = parametrosMensaje[2]
 
     if Colas.existeCola(nombreCola):
-        await canalSpamComandos.send(
-            f"Ya existe una cola con el nombre **{nombreCola}**!")
+        await channel.send(
+            f"Ya existe la cola **{nombreCola}**!")
         return False
 
-    Colas.agregarCola(nombreCola)
+    Colas.agregarCola(nombreCola, channel)
     await canalSpamComandos.send(
-        f"{tagAlAutor} ha creado una nueva cola llamada: **{str(nombreCola)}**."
+        f"{tagAlAutor} ha creado la cola **{str(nombreCola)}**."
     )
     await Colas.enviarMensajeNuevoEnCola(nombreCola)
 

--- a/src/comandos/comandoCreate.py
+++ b/src/comandos/comandoCreate.py
@@ -40,6 +40,6 @@ async def manejarComandoCreate(mensaje, autorMensaje, tagAlAutor, channel):
     await canalSpamComandos.send(
         f"{tagAlAutor} ha creado la cola **{str(nombreCola)}**."
     )
-    await Colas.enviarMensajeNuevoEnCola(nombreCola)
+    await Colas.enviarMensajeNuevoEnCola(nombreCola, channel)
 
     return True

--- a/src/comandos/comandoDelete.py
+++ b/src/comandos/comandoDelete.py
@@ -12,20 +12,20 @@ prefijoBot = Configs.prefijoBot
 
 # Description: Eliminar una cola
 # Access: Only Mods
-async def manejarComandoDelete(mensaje, autorMensaje, tagAlAutor):
+async def manejarComandoDelete(mensaje, autorMensaje, tagAlAutor, channel):
 
     # Verificacion de mod
     if not esMod(autorMensaje):
-        await printearErrorSinPermisos(autorMensaje, comandoDelete)
+        await printearErrorSinPermisos(autorMensaje, comandoDelete, channel)
         return False
 
-    canalSpamComandos = GlobalVariables.canalSpamComandos
+    canalSpamComandos = GlobalVariables.canalOutputComandos
 
     parametrosMensaje = mensaje.split(" ", 5)
 
     # Solo debe haber tres parametros
     if not cantidadDeParametrosEs(3, parametrosMensaje):
-        await canalSpamComandos.send(
+        await channel.send(
             f"Sintaxis incorrecta, uso: {prefijoBot} {comandoDelete} nombreCola`."
         )
         return False
@@ -33,7 +33,7 @@ async def manejarComandoDelete(mensaje, autorMensaje, tagAlAutor):
     nombreCola = parametrosMensaje[2]
 
     if not Colas.existeCola(nombreCola):
-        await canalSpamComandos.send(f"No existe la cola **{nombreCola}**!")
+        await channel.send(f"No existe la cola **{nombreCola}**!")
         return False
     else:
         await Colas.eliminarMensajeEnCola(nombreCola)

--- a/src/comandos/comandoHelp.py
+++ b/src/comandos/comandoHelp.py
@@ -1,6 +1,5 @@
 import discord
 
-from configs.globalVariables import GlobalVariables
 from configs.configs import Configs
 
 PREFIX = Configs.prefijoBot
@@ -15,7 +14,7 @@ imagenThumbnail = Configs.imagenThumbnail
 emojis = Configs.emojis
 
 
-def generarMensajeEmbed():
+def generarMensajeEmbedHelp():
     # Creacion de mensaje embed
     mensajeEmbed = discord.Embed(title="Lista de comandos:",
                                  color=discord.Color.purple())
@@ -49,11 +48,10 @@ def generarMensajeEmbed():
 
 # Description: Mostrar mensaje de ayuda
 # Access: Everyone
-async def manejarComandoHelp():
-    canalSpamComandos = GlobalVariables.canalSpamComandos
+async def manejarComandoHelp(channel):
 
-    mensajeEmbed = generarMensajeEmbed()
+    mensajeEmbed = generarMensajeEmbedHelp()
 
-    await canalSpamComandos.send(embed=mensajeEmbed)
+    await channel.send(embed=mensajeEmbed)
 
     return True

--- a/src/comandos/comandoList.py
+++ b/src/comandos/comandoList.py
@@ -33,6 +33,6 @@ async def manejarComandoList(mensaje, autorMensaje, channel):
         await channel.send(f"No existe la cola **{nombreCola}**!")
         return False
 
-    await Colas.enviarMensajeNuevoEnCola(nombreCola)
+    await Colas.enviarMensajeNuevoEnCola(nombreCola, channel)
 
     return True

--- a/src/comandos/comandoList.py
+++ b/src/comandos/comandoList.py
@@ -1,4 +1,3 @@
-from configs.globalVariables import GlobalVariables
 from configs.configs import Configs
 
 from utils.utils import esMod
@@ -12,20 +11,18 @@ prefijoBot = Configs.prefijoBot
 
 # Description: Muestra una cola por output-bot
 # Access: Only Mods
-async def manejarComandoList(mensaje, autorMensaje):
+async def manejarComandoList(mensaje, autorMensaje, channel):
 
     # Verificacion de mod
     if not esMod(autorMensaje):
-        await printearErrorSinPermisos(autorMensaje, comandoList)
+        await printearErrorSinPermisos(autorMensaje, comandoList, channel)
         return False
-
-    canalSpamComandos = GlobalVariables.canalSpamComandos
 
     parametrosMensaje = mensaje.split(" ", 5)
 
     # Solo debe haber tres parametros
     if not cantidadDeParametrosEs(3, parametrosMensaje):
-        await canalSpamComandos.send(
+        await channel.send(
             f"Sintaxis incorrecta, uso: `{prefijoBot} {comandoList} nombreCola`"
         )
         return False
@@ -33,7 +30,7 @@ async def manejarComandoList(mensaje, autorMensaje):
     nombreCola = parametrosMensaje[2]
 
     if not Colas.existeCola(nombreCola):
-        await canalSpamComandos.send(f"No existe la cola **{nombreCola}**!")
+        await channel.send(f"No existe la cola **{nombreCola}**!")
         return False
 
     await Colas.enviarMensajeNuevoEnCola(nombreCola)

--- a/src/comandos/comandoNext.py
+++ b/src/comandos/comandoNext.py
@@ -1,4 +1,3 @@
-from configs.globalVariables import GlobalVariables
 from configs.configs import Configs
 
 from utils.utils import esMod
@@ -12,20 +11,17 @@ prefijoBot = Configs.prefijoBot
 
 # Description: Atender siguiente persona en una cola
 # Access: Only Mods
-async def manejarComandoNext(mensaje, autorMensaje):
+async def manejarComandoNext(mensaje, autorMensaje, channel):
     # Verificacion de mod
     if not esMod(autorMensaje):
-        await printearErrorSinPermisos(autorMensaje, comandoNext)
+        await printearErrorSinPermisos(autorMensaje, comandoNext, channel)
         return False
-
-    canalSpamComandos = GlobalVariables.canalSpamComandos
-    canalOutputBot = GlobalVariables.canalOutputBot
 
     parametrosMensaje = mensaje.split(" ", 5)
 
     # Solo debe haber tres parametros {!queue}, {create}, {elNombre}
     if not cantidadDeParametrosEs(3, parametrosMensaje):
-        await canalSpamComandos.send(
+        await channel.send(
             f"Sintaxis incorrecta, uso: `{prefijoBot} {comandoNext} nombreCola`."
         )
         return False
@@ -33,8 +29,8 @@ async def manejarComandoNext(mensaje, autorMensaje):
     nombreCola = parametrosMensaje[2]
 
     if not Colas.existeCola(nombreCola):
-        await canalSpamComandos.send(f"No existe la cola **{nombreCola}**!")
+        await channel.send(f"No existe la cola **{nombreCola}**!")
         return False
 
-    await Colas.enviarMensajeNextEnCola(nombreCola, canalOutputBot)
+    await Colas.enviarMensajeNextEnCola(nombreCola)
     return True

--- a/src/comandos/comandoPrint.py
+++ b/src/comandos/comandoPrint.py
@@ -7,12 +7,12 @@ from utils.utils import printearErrorSinPermisos
 comandoPrint = "print"
 
 
-async def manejarComandoPrint(autorMensaje):
-    canalSpamComandos = GlobalVariables.canalSpamComandos
+async def manejarComandoPrint(autorMensaje, channel):
+    canalSpamComandos = GlobalVariables.canalOutputComandos
 
     # Verificacion de mod
     if not esMod(autorMensaje):
-        await printearErrorSinPermisos(autorMensaje, comandoPrint)
+        await printearErrorSinPermisos(autorMensaje, comandoPrint, channel)
         return False
 
     await Colas.printeameLasColas(canalSpamComandos)

--- a/src/comandos/comandoRemove.py
+++ b/src/comandos/comandoRemove.py
@@ -4,21 +4,20 @@ from configs.configs import Configs
 from clases.colas import Colas
 from utils.utils import cantidadDeParametrosEs
 
-
 comandoRemove = Configs.comandoRemove
 prefijoBot = Configs.prefijoBot
 
 
 # Description: Eliminar una persona de una cola
 # Access: Everyone
-async def manejarComandoRemove(mensaje, autorMensaje, tagAlAutor):
-    canalSpamComandos = GlobalVariables.canalSpamComandos
+async def manejarComandoRemove(mensaje, autorMensaje, tagAlAutor, channel):
+    canalSpamComandos = GlobalVariables.canalOutputComandos
 
     parametrosMensaje = mensaje.split(" ", 5)
 
     # Solo debe haber tres parametros
     if not cantidadDeParametrosEs(3, parametrosMensaje):
-        await canalSpamComandos.send(
+        await channel.send(
             f"Sintaxis incorrecta, uso: `{prefijoBot} {comandoRemove} nombreCola`."
         )
         return False
@@ -26,11 +25,11 @@ async def manejarComandoRemove(mensaje, autorMensaje, tagAlAutor):
     nombreCola = parametrosMensaje[2]
 
     if not Colas.existeCola(nombreCola):
-        await canalSpamComandos.send(f"No existe la cola **{nombreCola}**!")
+        await channel.send(f"No existe la cola **{nombreCola}**!")
         return False
 
     if not Colas.existeUsuarioEnCola(autorMensaje, nombreCola):
-        await canalSpamComandos.send(
+        await channel.send(
             f"{tagAlAutor} no estas en la cola **{nombreCola}**!")
         return False
 

--- a/src/configs/configs.py
+++ b/src/configs/configs.py
@@ -18,8 +18,6 @@ class Configs:
     DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
     # Canal Spam Comandos | Int | Canal donde el bot hace output de los comandos recibidos
     CANAL_OUTPUT_COMANDOS_ID = obtenerCanal("CANAL_OUTPUT_COMANDOS_ID")
-    # Canal Output Bot | Int | Canal donde el bot envia la informacion sobre las colas
-    CANAL_OUTPUT_COLAS_ID = obtenerCanal("CANAL_OUTPUT_COLAS_ID")
     # Rangos Mod | [Int] | IDs de los rangos de moderacion que tendran permisos totales
     RANGOS_MOD = obtenerRangos("RANGOS_MOD")
 

--- a/src/configs/globalVariables.py
+++ b/src/configs/globalVariables.py
@@ -1,3 +1,3 @@
 class GlobalVariables:
-    canalOutputBot = None
-    canalSpamComandos = None
+    # canalOutputBot = None
+    canalOutputComandos = None

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1,4 +1,3 @@
-from configs.globalVariables import GlobalVariables
 from configs.configs import Configs
 
 # Configs
@@ -23,8 +22,7 @@ def esMod(unUsuario):
 
 
 # Printea error cuando un usuario no tiene permisos para un comando
-async def printearErrorSinPermisos(autorMensaje, nombreComando):
-    canalSpamComandos = GlobalVariables.canalSpamComandos
+async def printearErrorSinPermisos(autorMensaje, nombreComando, channel):
     print("[PermissionError] El usuario " + autorMensaje.name +
           " intento usar el comando " + nombreComando + ".")
-    await canalSpamComandos.send("No tenes permiso para usar este comando.")
+    await channel.send("No tenes permiso para usar este comando.")


### PR DESCRIPTION
This PR Fixes issue #10 

- Now queues are created on the channel where the `create` command was sent. All the output related to that queue will be in that channel during its lifecycle.
- `CANAL_OUTPUT_COLAS_ID` env var is now deprecated. This channel is no longer needed.
- If a `list` command of a queue is sent outside the original channel, this will simply change the output channel to be that new channel and from that moment onwards show it there.

Extra:
- All output from the bot which is targeted towards a specific user is shown in the same channel where the command was sent.
- The channel `CANAL_OUTPUT_COMANDOS_ID` is now used only for logging general actions related to queues.